### PR TITLE
Add support for Laravel 9 and phpcsfixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
 name: CI
 
-env:
-  COMPOSE_INTERACTIVE_NO_CLI: 1
-  PHP_CS_FIXER_IGNORE_ENV: 1
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 on:
   push:
   pull_request:
@@ -30,7 +25,7 @@ jobs:
       - name: Install php-cs-fixer
         run: composer global require friendsofphp/php-cs-fixer
       - name: Run php-cs-fixer
-        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config=.php_cs.php
+        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
       - name: Commit changes from php-cs-fixer
         uses: EndBug/add-and-commit@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,16 @@ on:
 
 jobs:
   phpunit:
-    name: Tests (PHPUnit)
+    name: Tests (PHPUnit) L${{ matrix.laravel }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        laravel: [8, 9]
 
     steps:
     - uses: actions/checkout@v2
     - name: Install composer dependencies
-      run: composer install
+      run: composer require "laravel/framework:^${{matrix.laravel}}.0"
     - name: Run tests
       run: vendor/bin/phpunit
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 .vscode/
 coverage/
 node_modules
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,141 @@
+<?php
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$rules = [
+    'array_syntax' => ['syntax' => 'short'],
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [
+            '=>' => null,
+            '|' => 'no_space',
+        ],
+    ],
+    'blank_line_after_namespace' => true,
+    'blank_line_after_opening_tag' => true,
+    'no_superfluous_phpdoc_tags' => true,
+    'blank_line_before_statement' => [
+        'statements' => ['return'],
+    ],
+    'braces' => true,
+    'cast_spaces' => true,
+    'class_definition' => true,
+    'concat_space' => [
+        'spacing' => 'one',
+    ],
+    'declare_equal_normalize' => true,
+    'elseif' => true,
+    'encoding' => true,
+    'full_opening_tag' => true,
+    'declare_strict_types' => true,
+    'fully_qualified_strict_types' => true, // added by Shift
+    'function_declaration' => true,
+    'function_typehint_space' => true,
+    'heredoc_to_nowdoc' => true,
+    'include' => true,
+    'increment_style' => ['style' => 'post'],
+    'indentation_type' => true,
+    'linebreak_after_opening_tag' => true,
+    'line_ending' => true,
+    'lowercase_cast' => true,
+    'constant_case' => true,
+    'lowercase_keywords' => true,
+    'lowercase_static_reference' => true, // added from Symfony
+    'magic_method_casing' => true, // added from Symfony
+    'magic_constant_casing' => true,
+    'method_argument_space' => true,
+    'native_function_casing' => true,
+    'no_alias_functions' => true,
+    'no_extra_blank_lines' => [
+        'tokens' => [
+            'extra',
+            'throw',
+            'use',
+            'use_trait',
+        ],
+    ],
+    'no_blank_lines_after_class_opening' => true,
+    'no_blank_lines_after_phpdoc' => true,
+    'no_closing_tag' => true,
+    'no_empty_phpdoc' => true,
+    'no_empty_statement' => true,
+    'no_leading_import_slash' => true,
+    'no_leading_namespace_whitespace' => true,
+    'no_mixed_echo_print' => [
+        'use' => 'echo',
+    ],
+    'no_multiline_whitespace_around_double_arrow' => true,
+    'multiline_whitespace_before_semicolons' => [
+        'strategy' => 'no_multi_line',
+    ],
+    'no_short_bool_cast' => true,
+    'no_singleline_whitespace_before_semicolons' => true,
+    'no_spaces_after_function_name' => true,
+    'no_spaces_around_offset' => true,
+    'no_spaces_inside_parenthesis' => true,
+    'no_trailing_comma_in_list_call' => true,
+    'no_trailing_comma_in_singleline_array' => true,
+    'no_trailing_whitespace' => true,
+    'no_trailing_whitespace_in_comment' => true,
+    'no_unneeded_control_parentheses' => true,
+    'no_unreachable_default_argument_value' => true,
+    'no_useless_return' => true,
+    'no_whitespace_before_comma_in_array' => true,
+    'no_whitespace_in_blank_line' => true,
+    'normalize_index_brace' => true,
+    'not_operator_with_successor_space' => true,
+    'object_operator_without_whitespace' => true,
+    'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    'phpdoc_indent' => true,
+    'general_phpdoc_tag_rename' => true,
+    'phpdoc_no_access' => true,
+    'phpdoc_no_package' => true,
+    'phpdoc_no_useless_inheritdoc' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_single_line_var_spacing' => true,
+    'phpdoc_summary' => true,
+    'phpdoc_to_comment' => false,
+    'phpdoc_trim' => true,
+    'phpdoc_types' => true,
+    'phpdoc_var_without_name' => true,
+    'psr_autoloading' => true,
+    'self_accessor' => true,
+    'short_scalar_cast' => true,
+    'simplified_null_return' => false, // disabled by Shift
+    'single_blank_line_at_eof' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_class_element_per_statement' => true,
+    'single_import_per_statement' => false,
+    'single_line_after_imports' => true,
+    'no_unused_imports' => true,
+    'single_line_comment_style' => [
+        'comment_types' => ['hash'],
+    ],
+    'single_quote' => true,
+    'space_after_semicolon' => true,
+    'standardize_not_equals' => true,
+    'switch_case_semicolon_to_colon' => true,
+    'switch_case_space' => true,
+    'ternary_operator_spaces' => true,
+    'trailing_comma_in_multiline' => true,
+    'trim_array_spaces' => true,
+    'unary_operator_spaces' => true,
+    'whitespace_after_comma_in_array' => true,
+];
+
+$project_path = getcwd();
+$finder = Finder::create()
+    ->in([
+        $project_path . '/src',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return (new Config())
+    ->setFinder($finder)
+    ->setRules($rules)
+    ->setRiskyAllowed(true)
+    ->setUsingCache(true);

--- a/check
+++ b/check
@@ -16,21 +16,21 @@ offer_run() {
     exit 1
 }
 
-if (php-cs-fixer fix --dry-run --config=.php_cs.php > /dev/null 2>/dev/null); then
+if (php-cs-fixer fix --dry-run --config=.php-cs-fixer.php > /dev/null 2>/dev/null); then
     echo '✅ php-cs-fixer OK'
 else
     read -p "⚠️ php-cs-fixer found issues. Fix (Y/n)? " fix
     case ${fix:0:1} in
         n|N )
             echo '❌ php-cs-fixer FAIL'
-            offer_run 'php-cs-fixer fix --config=.php_cs.php'
+            offer_run 'php-cs-fixer fix --config=.php-cs-fixer.php'
         ;;
         * )
-            if (php-cs-fixer fix --config=.php_cs.php > /dev/null 2>/dev/null); then
+            if (php-cs-fixer fix --config=.php-cs-fixer.php > /dev/null 2>/dev/null); then
                 echo '✅ php-cs-fixer OK'
             else
                 echo '❌ php-cs-fixer FAIL'
-                offer_run 'php-cs-fixer fix --config=.php_cs.php'
+                offer_run 'php-cs-fixer fix --config=.php-cs-fixer.php'
             fi
         ;;
     esac

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^6.9|^7.0"
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     },
     "require": {
         "php": "^8.0",
-        "livewire/livewire": "^2.4"
+        "livewire/livewire": "^2.10"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.9"
+        "orchestra/testbench": "^6.9|^7.0"
     }
 }

--- a/src/BlockFrontendAccess.php
+++ b/src/BlockFrontendAccess.php
@@ -6,7 +6,7 @@ namespace Lean\LivewireAccess;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_PROPERTY|Attribute::TARGET_METHOD)]
 class BlockFrontendAccess
 {
 }

--- a/src/FrontendAccess.php
+++ b/src/FrontendAccess.php
@@ -6,7 +6,7 @@ namespace Lean\LivewireAccess;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_PROPERTY|Attribute::TARGET_METHOD)]
 class FrontendAccess
 {
 }


### PR DESCRIPTION
This package does not use Laravel components except one for dev `orchestra/testbench`. Livewire now supports Laravel 9 so our package. Other than that added the phpcsfixer, check the script, and simplify the CI file.